### PR TITLE
harden session cookies making same_site strict and httponly

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -5,4 +5,6 @@
 # match this in nginx config for bypassing the file cache
 Lobsters::Application.config.session_store :cookie_store,
   key: "lobster_trap",
-  expire_after: 1.month
+  expire_after: 1.month,
+  same_site: :strict,
+  httponly: true


### PR DESCRIPTION
Was chatting with @pushcx during lobste.rs office hours and discussing options, while yak shaving development improvements; one of the options was disqualified for the desire to protect user accounts. This change hardens the settings for session cookies, restricting the surfaces that are able to access these cookies.

So, technically, this patch is just a guess, because either I'm not searching correctly, or there doesn't appear to be docs describing this exact behavior. https://api.rubyonrails.org/v5.2.1/classes/ActionDispatch/Session/CookieStore.html is the closest I was able to find, but the docs lack the behavior confirmation I'd hope to see. I was able to find tests that I think enforce this behavior, but I don't wanna assert confidence yet, not until I see the cookie attrib set correctly in prod.

Please excuse any omissions, I don't write ruby so it's magic is still magic to me :)